### PR TITLE
fix: rename ci main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ mhl-ordum ]
+    branches: [ main ]
   pull_request:
-    branches: [ mhl-ordum ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
mhl-ordum is now `main`
old `main` was renamed into `mhl-main`